### PR TITLE
Mock gettable

### DIFF
--- a/internal/testutils/configmock.go
+++ b/internal/testutils/configmock.go
@@ -58,10 +58,16 @@ func randomBool() bool {
 	return rand.Intn(2) == 0
 }
 
+func RandomMockConfigurationA() MockConfigurationA {
+	return MockConfigurationA{
+		Value: randomString(),
+	}
+}
+
 func RandomMockConfigurationWithDuplicates() MockConfigurationWithDuplicates {
 	return MockConfigurationWithDuplicates{
-		A:  MockConfigurationA{Value: randomString()},
-		A2: MockConfigurationA{Value: randomString()},
+		A:  RandomMockConfigurationA(),
+		A2: RandomMockConfigurationA(),
 		B:  MockConfigurationB{Value: randomBool()},
 	}
 }
@@ -76,16 +82,14 @@ func RandomMockConfigurationWithTypedef() MockConfigurationWithTypedef {
 
 func RandomMockConfigurationWithOneDepthLevel() MockConfigurationWithOneDepthLevel {
 	return MockConfigurationWithOneDepthLevel{
-		A: MockConfigurationA{Value: randomString()},
+		A: RandomMockConfigurationA(),
 		B: MockConfigurationB{Value: randomBool()},
 	}
 }
 
 func RandomMockConfigurationWithA() MockConfigurationWithA {
 	return MockConfigurationWithA{
-		A: MockConfigurationA{
-			Value: randomString(),
-		},
+		A: RandomMockConfigurationA(),
 	}
 }
 

--- a/pkg/getter/README.md
+++ b/pkg/getter/README.md
@@ -31,3 +31,24 @@ err := nextLevelGetter.Register(callback)
 
 Like so, the module above only needs access to `nextLevelGetter`.
 If the path to its configuration alters, it doesn't need to be aware: only the module that initiates it needs be.
+
+## Testing
+
+When testing a dynamically-configurable module that uses a getter, mocks can be used.
+The following example sets a getter that when passed to a module that uses it, handles `Get` or `Registers` as requested inline.
+An example module that uses `Register` can have its configuration reload logic tested by triggering the registered callback directly.
+
+```go
+getter.NewDynamicConfigurationGetter(
+	getter.NewMockDynamicConfigurationGettableWithType(
+		func(path []string, out *ConfigurationType) error {
+			*out = myConfiguration
+			return nil
+		},
+		func(path []string, callback func(a ConfigurationType) error) error {
+			myCallback = callback // store the callback to push new configuration later if needed
+			return callback(myConfiguration)
+		},
+	),
+)
+```

--- a/pkg/getter/gettable.go
+++ b/pkg/getter/gettable.go
@@ -1,0 +1,29 @@
+package getter
+
+type DynamicConfigurationGettable interface {
+	Register(path []string, callback any) error
+	Get(path []string, out any) error
+}
+
+type MockDynamicConfigurationGettable struct {
+	register func(path []string, callback any) error
+	get      func(path []string, out any) error
+}
+
+func NewMockDynamicConfigurationGettable(
+	register func(path []string, callback any) error,
+	get func(path []string, out any) error,
+) *MockDynamicConfigurationGettable {
+	return &MockDynamicConfigurationGettable{
+		register: register,
+		get:      get,
+	}
+}
+
+func (gettable *MockDynamicConfigurationGettable) Register(path []string, callback any) error {
+	return gettable.register(path, callback)
+}
+
+func (gettable *MockDynamicConfigurationGettable) Get(path []string, out any) error {
+	return gettable.get(path, out)
+}

--- a/pkg/getter/gettable.go
+++ b/pkg/getter/gettable.go
@@ -31,17 +31,17 @@ func (gettable *MockDynamicConfigurationGettable) Get(path []string, out any) er
 }
 
 type MockDynamicConfigurationGettableWithType[T any] struct {
-	register func(path []string, callback func(T) error) error
 	get      func(path []string, out *T) error
+	register func(path []string, callback func(T) error) error
 }
 
 func NewMockDynamicConfigurationGettableWithType[T any](
-	register func(path []string, callback func(T) error) error,
 	get func(path []string, out *T) error,
+	register func(path []string, callback func(T) error) error,
 ) *MockDynamicConfigurationGettableWithType[T] {
 	return &MockDynamicConfigurationGettableWithType[T]{
-		register: register,
 		get:      get,
+		register: register,
 	}
 }
 

--- a/pkg/getter/gettable.go
+++ b/pkg/getter/gettable.go
@@ -22,6 +22,13 @@ func NewMockDynamicConfigurationGettable(
 	}
 }
 
+func NewNoopDynamicConfigurationGettable() *MockDynamicConfigurationGettable {
+	return &MockDynamicConfigurationGettable{
+		register: func(path []string, callback any) error { return nil },
+		get:      func(path []string, out any) error { return nil },
+	}
+}
+
 func (gettable *MockDynamicConfigurationGettable) Register(path []string, callback any) error {
 	return gettable.register(path, callback)
 }

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -2,11 +2,6 @@ package getter
 
 import "slices"
 
-type DynamicConfigurationGettable interface {
-	Register(path []string, callback any) error
-	Get(path []string, out any) error
-}
-
 type DynamicConfigurationGetter struct {
 	gettable DynamicConfigurationGettable
 	prefix   []string

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -35,16 +35,3 @@ func (getter *DynamicConfigurationGetter) Select(selection string) *DynamicConfi
 		prefix:   append(slices.Clone(getter.prefix), selection),
 	}
 }
-
-type MockDynamicConfigurationGetter[T any] struct {
-	gettable DynamicConfigurationGettable
-	prefix   []string
-}
-
-func (getter *MockDynamicConfigurationGetter[T]) Register(callback func(T) error) error {
-	return getter.gettable.Register([]string{}, callback)
-}
-
-func (getter *MockDynamicConfigurationGetter[T]) Get(out *T) error {
-	return getter.gettable.Get([]string{}, out)
-}

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -35,3 +35,16 @@ func (getter *DynamicConfigurationGetter) Select(selection string) *DynamicConfi
 		prefix:   append(slices.Clone(getter.prefix), selection),
 	}
 }
+
+type MockDynamicConfigurationGetter[T any] struct {
+	gettable DynamicConfigurationGettable
+	prefix   []string
+}
+
+func (getter *MockDynamicConfigurationGetter[T]) Register(callback func(T) error) error {
+	return getter.gettable.Register([]string{}, callback)
+}
+
+func (getter *MockDynamicConfigurationGetter[T]) Get(out *T) error {
+	return getter.gettable.Get([]string{}, out)
+}


### PR DESCRIPTION
The mock gettable can be used in tests in order to return a specific configuration to a module that uses the getter without initiating a configuration manager